### PR TITLE
Kakao oauth 구현

### DIFF
--- a/backend/index.js
+++ b/backend/index.js
@@ -1,23 +1,22 @@
-import dotenv from 'dotenv';
+import dotenv from "dotenv";
 dotenv.config();
 
-import morgan from 'morgan';
-import express from 'express';
-import bodyParser from 'body-parser';
+import morgan from "morgan";
+import express from "express";
+import bodyParser from "body-parser";
 
-import routes from './routes/index.js'
+import routes from "./routes/index.js";
 
-const PORT = process.env.PORT || '🥰😡🥲😵‍💫';
+const PORT = process.env.PORT || "🥰😡🥲😵‍💫";
 
 const app = express();
 
 app
-    .use(morgan('dev'))
-    .use(express.urlencoded({ extended: false }))
-    .use(express.json())
-    .use('/', routes);
-
+  .use(morgan("dev"))
+  .use(express.urlencoded({ extended: true }))
+  .use(express.json())
+  .use("/", routes);
 
 app.listen(PORT, () => {
-    console.log(`Listening Server to ${PORT}`)
-})
+  console.log(`Listening Server to ${PORT}`);
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "body-parser": "^1.20.0",
     "connect": "^3.7.0",
     "cors": "^2.8.5",
-    "express": "^4.18.1"
+    "express": "^4.18.1",
+    "qs": "^6.11.0"
   },
   "devDependencies": {
     "dotenv": "^16.0.1",

--- a/backend/routes/auth/getAuthKaKaoToken.js
+++ b/backend/routes/auth/getAuthKaKaoToken.js
@@ -11,9 +11,9 @@ const getAuthKaKaoToken = async (req, res) => {
     const data = {
       grant_type: "authorization_code",
       code,
-      client_id: "2bb5c7a6e6674d807b20622e015c0b89",
-      redirect_uri: "http://localhost:3000/kakao-login",
-      client_secret: "KNwdz0CJzXgTvkPCsDnLqjPDPYEawpke",
+      client_id: process.env.KAKAO_REST_API_KEY,
+      redirect_uri: process.env.KAKAO_REDIRECT_URI,
+      client_secret: process.env.KAKAO_CLIENT_SECRET,
     };
 
     const result = await axios.post(

--- a/backend/routes/auth/getAuthKaKaoToken.js
+++ b/backend/routes/auth/getAuthKaKaoToken.js
@@ -1,0 +1,37 @@
+import axios from "axios";
+import qs from "qs";
+
+const getAuthKaKaoToken = async (req, res) => {
+  const query = req.query;
+  const code = query.code;
+
+  if (!code) return res.status(401).send();
+
+  try {
+    const data = {
+      grant_type: "authorization_code",
+      code,
+      client_id: "2bb5c7a6e6674d807b20622e015c0b89",
+      redirect_uri: "http://localhost:3000/kakao-login",
+      client_secret: "KNwdz0CJzXgTvkPCsDnLqjPDPYEawpke",
+    };
+
+    const result = await axios.post(
+      "https://kauth.kakao.com/oauth/token",
+      qs.stringify(data),
+      {
+        headers: {
+          "content-type": "application/x-www-form-urlencoded",
+        },
+      }
+    );
+
+    console.log(result);
+    return res.send(result.data);
+  } catch (e) {
+    console.log(e.data);
+    return res.json(e.data);
+  }
+};
+
+export default getAuthKaKaoToken;

--- a/backend/routes/auth/getAuthKaKaoToken.js
+++ b/backend/routes/auth/getAuthKaKaoToken.js
@@ -26,10 +26,8 @@ const getAuthKaKaoToken = async (req, res) => {
       }
     );
 
-    console.log(result);
     return res.send(result.data);
   } catch (e) {
-    console.log(e.data);
     return res.json(e.data);
   }
 };

--- a/backend/routes/auth/getKakaoUser.js
+++ b/backend/routes/auth/getKakaoUser.js
@@ -1,56 +1,26 @@
 import axios from "axios";
-import qs from "qs";
 
-// {
-//   public_keys: [
-//     "kakao_account.account_email",
-//     "kakao_account.people_nickname",
-//     "kakao_account.people_image",
-//     "kakao_account.gender",
-//     "kakao_account.age_range",
-//     "kakao_account.birthday",
-//     "kakao_account.friends",
-//     "kakao_account.story_permalink",
-//   ],
-// },
 const getKakaoUser = async (req, res) => {
   const authorizationCode = req.headers.authorization;
   try {
-    const result = await axios.get(
-      "https://kapi.kakao.com/v2/user/me",
-      // {
-      //   property_keys: [
-      //     "account_email",
-      //     "people_nickname",
-      //     "people_image",
-      //     "gender",
-      //     "age_range",
-      //     "birthday",
-      //     "friends",
-      //     "story_permalink",
-      //   ],
-      // },
-      {
-        headers: {
-          Authorization: authorizationCode,
-          "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
-        },
-        params: {
-          property_keys: [
-            "account_email",
-            "people_nickname",
-            "people_image",
-            "gender",
-            "age_range",
-            "birthday",
-          ],
-        },
-      }
-    );
-    console.log(result.data);
+    const result = await axios.get("https://kapi.kakao.com/v2/user/me", {
+      headers: {
+        Authorization: authorizationCode,
+        "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+      },
+      params: {
+        property_keys: [
+          "account_email",
+          "people_nickname",
+          "people_image",
+          "gender",
+          "age_range",
+          "birthday",
+        ],
+      },
+    });
     return res.status(200).json(result.data);
   } catch (e) {
-    console.log(e);
     return res.status(400).send(e);
   }
 };

--- a/backend/routes/auth/getKakaoUser.js
+++ b/backend/routes/auth/getKakaoUser.js
@@ -21,6 +21,7 @@ const getKakaoUser = async (req, res) => {
     });
     return res.status(200).json(result.data);
   } catch (e) {
+    console.log(e);
     return res.status(400).send(e);
   }
 };

--- a/backend/routes/auth/getKakaoUser.js
+++ b/backend/routes/auth/getKakaoUser.js
@@ -1,0 +1,57 @@
+import axios from "axios";
+import qs from "qs";
+
+// {
+//   public_keys: [
+//     "kakao_account.account_email",
+//     "kakao_account.people_nickname",
+//     "kakao_account.people_image",
+//     "kakao_account.gender",
+//     "kakao_account.age_range",
+//     "kakao_account.birthday",
+//     "kakao_account.friends",
+//     "kakao_account.story_permalink",
+//   ],
+// },
+const getKakaoUser = async (req, res) => {
+  const authorizationCode = req.headers.authorization;
+  try {
+    const result = await axios.get(
+      "https://kapi.kakao.com/v2/user/me",
+      // {
+      //   property_keys: [
+      //     "account_email",
+      //     "people_nickname",
+      //     "people_image",
+      //     "gender",
+      //     "age_range",
+      //     "birthday",
+      //     "friends",
+      //     "story_permalink",
+      //   ],
+      // },
+      {
+        headers: {
+          Authorization: authorizationCode,
+          "Content-Type": "application/x-www-form-urlencoded;charset=utf-8",
+        },
+        params: {
+          property_keys: [
+            "account_email",
+            "people_nickname",
+            "people_image",
+            "gender",
+            "age_range",
+            "birthday",
+          ],
+        },
+      }
+    );
+    console.log(result.data);
+    return res.status(200).json(result.data);
+  } catch (e) {
+    console.log(e);
+    return res.status(400).send(e);
+  }
+};
+export default getKakaoUser;

--- a/backend/routes/auth/index.js
+++ b/backend/routes/auth/index.js
@@ -1,18 +1,20 @@
-import express from 'express';
-import cors from 'cors';
+import express from "express";
+import cors from "cors";
 
-import checkValidToken from './checkValidToken.js';
-import deleteNaverAuth from './deleteNaverAuth.js';
+import checkValidToken from "./checkValidToken.js";
+import deleteNaverAuth from "./deleteNaverAuth.js";
+import getAuthKaKaoToken from "./getAuthKaKaoToken.js";
 
 const router = express.Router();
 const corsOptions = {
-    origin: 'http://localhost:3000',
-    Headers: ['Authorization']
-}
-router.get('/', (req, res) => {
-    res.send('AUTH ROUTES!')
-})
-router.get('/naver/check-valid-token', cors(corsOptions), checkValidToken);
-router.post('/naver/delete-auth', cors(corsOptions), deleteNaverAuth);
+  origin: "http://localhost:3000",
+  Headers: ["Authorization"],
+};
+router.get("/", (req, res) => {
+  res.send("AUTH ROUTES!");
+});
+router.get("/kakao/login", getAuthKaKaoToken);
+router.get("/naver/check-valid-token", cors(corsOptions), checkValidToken);
+router.post("/naver/delete-auth", cors(corsOptions), deleteNaverAuth);
 
 export default router;

--- a/backend/routes/auth/index.js
+++ b/backend/routes/auth/index.js
@@ -5,6 +5,7 @@ import checkValidToken from "./checkValidToken.js";
 import deleteNaverAuth from "./deleteNaverAuth.js";
 import getAuthKaKaoToken from "./getAuthKaKaoToken.js";
 import getKakaoUser from "./getKakaoUser.js";
+import kakaoUserLogout from "./kakaoUserLogout.js";
 
 const router = express.Router();
 const corsOptions = {
@@ -17,6 +18,7 @@ router.get("/", (req, res) => {
 });
 router.get("/kakao/login", getAuthKaKaoToken);
 router.get("/kakao/user", cors(corsOptions), getKakaoUser);
+router.get("/kakao/logout", kakaoUserLogout);
 router.get("/naver/check-valid-token", cors(corsOptions), checkValidToken);
 router.post("/naver/delete-auth", cors(corsOptions), deleteNaverAuth);
 

--- a/backend/routes/auth/index.js
+++ b/backend/routes/auth/index.js
@@ -4,16 +4,19 @@ import cors from "cors";
 import checkValidToken from "./checkValidToken.js";
 import deleteNaverAuth from "./deleteNaverAuth.js";
 import getAuthKaKaoToken from "./getAuthKaKaoToken.js";
+import getKakaoUser from "./getKakaoUser.js";
 
 const router = express.Router();
 const corsOptions = {
   origin: "http://localhost:3000",
   Headers: ["Authorization"],
 };
+
 router.get("/", (req, res) => {
   res.send("AUTH ROUTES!");
 });
 router.get("/kakao/login", getAuthKaKaoToken);
+router.get("/kakao/user", cors(corsOptions), getKakaoUser);
 router.get("/naver/check-valid-token", cors(corsOptions), checkValidToken);
 router.post("/naver/delete-auth", cors(corsOptions), deleteNaverAuth);
 

--- a/backend/routes/auth/kakaoUserLogout.js
+++ b/backend/routes/auth/kakaoUserLogout.js
@@ -1,0 +1,14 @@
+import axios from "axios";
+
+const kakaoUserLogout = async (req, res) => {
+  try {
+    const result = await axios.get(
+      `https://kauth.kakao.com/oauth/logout?client_id=${process.env.KAKAO_REST_API_KEY}&logout_redirect_uri=${process.KAKAO_LOGOUT_REDIRECT_URI}`
+    );
+    return res.send(result);
+  } catch (e) {
+    return res.send(e);
+  }
+};
+
+export default kakaoUserLogout;

--- a/backend/yarn.lock
+++ b/backend/yarn.lock
@@ -576,6 +576,13 @@ qs@6.10.3:
   dependencies:
     side-channel "^1.0.4"
 
+qs@^6.11.0:
+  version "6.11.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
+  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
+  dependencies:
+    side-channel "^1.0.4"
+
 range-parser@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/range-parser/-/range-parser-1.2.1.tgz#3cf37023d199e1c24d1a55b84800c2f3e6468031"

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -10,8 +10,13 @@
       content="Web site created using create-react-app"
     />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
+
+    <!-- Naver Oauth -->
     <script type="text/javascript" src="https://static.nid.naver.com/js/naveridlogin_js_sdk_2.0.0.js"charset="utf-8"></script>
     <script type="text/javascript" src="http://code.jquery.com/jquery-1.11.3.min.js"></script>
+
+    <!-- kakao Oauth -->
+    <script src="https://developers.kakao.com/sdk/js/kakao.js"></script>
     <!--
       manifest.json provides metadata used when your web app is installed on a
       user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Routes, Route} from "react-router-dom";
 import IndexPage from "./pages/IndexPage";
 import NaverLoginPage from "./pages/NaverLoginPage";
+import KakaoLoginPage from "./pages/KakaoLoginPage";
 
 function App() {
 
@@ -9,6 +10,7 @@ function App() {
         <BrowserRouter>
           <Routes>
             <Route path="/naver-login" element={< NaverLoginPage />}></Route>
+            <Route path="/kakao-login" element={< KakaoLoginPage />}></Route>
             <Route path="/" element={< IndexPage />}></Route>
           </Routes>
         </BrowserRouter>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,19 +1,18 @@
-import { BrowserRouter, Routes, Route} from "react-router-dom";
+import { BrowserRouter, Routes, Route } from "react-router-dom";
 import IndexPage from "./pages/IndexPage";
 import NaverLoginPage from "./pages/NaverLoginPage";
 import KakaoLoginPage from "./pages/KakaoLoginPage";
 
 function App() {
-
   return (
     <div className="App">
-        <BrowserRouter>
-          <Routes>
-            <Route path="/naver-login" element={< NaverLoginPage />}></Route>
-            <Route path="/kakao-login" element={< KakaoLoginPage />}></Route>
-            <Route path="/" element={< IndexPage />}></Route>
-          </Routes>
-        </BrowserRouter>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/naver-login" element={<NaverLoginPage />}></Route>
+          <Route path="/kakao-login" element={<KakaoLoginPage />}></Route>
+          <Route path="/" element={<IndexPage />}></Route>
+        </Routes>
+      </BrowserRouter>
     </div>
   );
 }

--- a/client/src/api/auth/kakao/getAuthToken.ts
+++ b/client/src/api/auth/kakao/getAuthToken.ts
@@ -1,7 +1,7 @@
 import request from "../..";
 
 const getAuthToken = async (code) => {
-  const res = await request.get(`/auth/kakao-login`, {
+  const res = await request.get(`/auth/kakao/login`, {
     params: {
       code,
     },

--- a/client/src/api/auth/kakao/getAuthToken.ts
+++ b/client/src/api/auth/kakao/getAuthToken.ts
@@ -1,0 +1,13 @@
+import request from "../..";
+
+const getAuthToken = async (code) => {
+  const res = await request.get(`/auth/kakao-login`, {
+    params: {
+      code,
+    },
+  });
+
+  return res;
+};
+
+export default getAuthToken;

--- a/client/src/api/auth/kakao/getAuthToken.ts
+++ b/client/src/api/auth/kakao/getAuthToken.ts
@@ -7,7 +7,7 @@ const getAuthToken = async (code) => {
     },
   });
 
-  return res;
+  return res.data;
 };
 
 export default getAuthToken;

--- a/client/src/api/auth/kakao/getKakaoUserInfo.ts
+++ b/client/src/api/auth/kakao/getKakaoUserInfo.ts
@@ -1,0 +1,13 @@
+import request from "../..";
+
+const getKakaoUserInfo = async (token) => {
+  const res = await request.get("/auth/kakao/user", {
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+  });
+
+  return res.data;
+};
+
+export default getKakaoUserInfo;

--- a/client/src/api/auth/kakao/kakaoUserLogout.ts
+++ b/client/src/api/auth/kakao/kakaoUserLogout.ts
@@ -1,0 +1,9 @@
+import axios from "axios";
+
+const kakaoUserLogout = async () => {
+  const res = await axios.get("auth/kakao/logout");
+
+  return res;
+};
+
+export default kakaoUserLogout;

--- a/client/src/api/index.ts
+++ b/client/src/api/index.ts
@@ -1,7 +1,7 @@
 import axios from "axios";
 
 const request = axios.create({
-  baseURL: process.env.REACT_APP_BASE_URL
-})
+  baseURL: process.env.REACT_APP_BASE_URL,
+});
 
 export default request;

--- a/client/src/contexts/UserContext.tsx
+++ b/client/src/contexts/UserContext.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useMemo, useState } from "react";
+import React, { ReactNode, useEffect, useMemo, useState } from "react";
 
 export interface User {
   [info: string]: any;
@@ -12,29 +12,38 @@ export interface UserContextType extends UserInfo {
 }
 
 const initialState = {
-  accessToken: '',
-  userInfo: {}
-}
-export const UserContext = React.createContext<UserContextType>(initialState)
+  accessToken: "",
+  userInfo: {},
+};
+export const UserContext = React.createContext<UserContextType>(initialState);
 
 interface Props {
-  children: ReactNode
+  children: ReactNode;
 }
 
 const UserProvider = ({ children }: Props) => {
   const [userInfo, setUserInfo] = useState(() => ({}));
-  const [accessToken, setAccessToken] = useState(() => '');
+  const [accessToken, setAccessToken] = useState(() => "");
 
-  const value = useMemo(() => ({
-    userInfo,
-    accessToken,
-    setUserInfo,
-    setAccessToken
-  }), [userInfo, accessToken, setUserInfo, setAccessToken])
+  useEffect(() => {
+    const token = window.localStorage.getItem("access_token");
 
-  return (
-    <UserContext.Provider value={value}>{children}</UserContext.Provider>
-  )
-}
+    if (token) {
+      setAccessToken(() => JSON.parse(token));
+    }
+  }, []);
+
+  const value = useMemo(
+    () => ({
+      userInfo,
+      accessToken,
+      setUserInfo,
+      setAccessToken,
+    }),
+    [userInfo, accessToken, setUserInfo, setAccessToken]
+  );
+
+  return <UserContext.Provider value={value}>{children}</UserContext.Provider>;
+};
 
 export default UserProvider;

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,19 +1,17 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import reportWebVitals from './reportWebVitals';
-import ContextStore from './contexts';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import reportWebVitals from "./reportWebVitals";
+import ContextStore from "./contexts";
 
 const root = ReactDOM.createRoot(
-  document.getElementById('root') as HTMLElement
+  document.getElementById("root") as HTMLElement
 );
 root.render(
-  <React.StrictMode>
-    <ContextStore>
-      <App />
-    </ContextStore>
-  </React.StrictMode>
+  <ContextStore>
+    <App />
+  </ContextStore>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/client/src/index.tsx
+++ b/client/src/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { StrictMode } from "react";
 import ReactDOM from "react-dom/client";
 import "./index.css";
 import App from "./App";
@@ -9,9 +9,11 @@ const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
 );
 root.render(
-  <ContextStore>
-    <App />
-  </ContextStore>
+  <StrictMode>
+    <ContextStore>
+      <App />
+    </ContextStore>
+  </StrictMode>
 );
 
 // If you want to start measuring performance in your app, pass a function

--- a/client/src/pages/IndexPage.tsx
+++ b/client/src/pages/IndexPage.tsx
@@ -1,7 +1,6 @@
-
-import axios from 'axios';
-import React, { useContext, useEffect, useState } from 'react'
-import { UserContext } from '../contexts/UserContext';
+import axios from "axios";
+import React, { useContext, useEffect, useState } from "react";
+import { UserContext } from "../contexts/UserContext";
 
 declare global {
   interface Window {
@@ -10,23 +9,29 @@ declare global {
 }
 
 const IndexPage = () => {
-  const { accessToken, setAccessToken, userInfo, setUserInfo } = useContext(UserContext);
+  const { accessToken, setAccessToken, userInfo, setUserInfo } =
+    useContext(UserContext);
 
   const onLogout = async () => {
-    const res = await axios.post('auth/naver/delete-auth', {
-      client_id: process.env.REACT_APP_NAVER_CLIENT_ID,
-      client_secret: process.env.REACT_APP_NAVER_SECRET,
-      accessToken,
-      grant_type: 'delete'
-    }, {
-      headers: {
-        'X-Naver-Client-Id': process.env.REACT_APP_NAVER_CLIENT_ID as string, 
-        'X-Naver-Client-Secret': process.env.REACT_APP_NAVER_SECRET as string,
+    const res = await axios.post(
+      "auth/naver/delete-auth",
+      {
+        client_id: process.env.REACT_APP_NAVER_CLIENT_ID,
+        client_secret: process.env.REACT_APP_NAVER_SECRET,
+        accessToken,
+        grant_type: "delete",
+      },
+      {
+        headers: {
+          "X-Naver-Client-Id": process.env.REACT_APP_NAVER_CLIENT_ID as string,
+          "X-Naver-Client-Secret": process.env.REACT_APP_NAVER_SECRET as string,
+        },
       }
-    })
-    console.log(res)
-  }
-  // const url = window.opener.document.location.href; 
+    );
+    console.log(res);
+  };
+
+  // const url = window.opener.document.location.href;
   const initializeNaverLogin = () => {
     const callbackUrl = `http://localhost:3000/naver-login`;
 
@@ -35,52 +40,50 @@ const IndexPage = () => {
       callbackUrl,
       isPopup: false,
       callbackHandle: true,
-      loginButton: { color: 'white', type: 2, height: '45'}
+      loginButton: { color: "white", type: 2, height: "45" },
     });
 
     naverLogin.init();
-  }
+  };
 
   useEffect(() => {
-    const token = localStorage.getItem('access_token');
-    setAccessToken(() => token)
+    const token = localStorage.getItem("access_token");
+    setAccessToken(() => token);
 
     async function getFn() {
-      const res = await axios.get('/auth/naver/check-valid-token', {
+      const res = await axios.get("/auth/naver/check-valid-token", {
         headers: {
           Authorization: `Bearer ${token as string}`,
-        }
-      })
+        },
+      });
 
       setUserInfo((state) => ({
         ...state,
         ...res.data.response,
-      }))
+      }));
     }
 
-    initializeNaverLogin()
-    getFn()
+    initializeNaverLogin();
+    getFn();
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
-  }, [])
-
+  }, []);
 
   const [kakaoLogin, setKakaoLogin] = useState<any>(null);
-  
+
   useEffect(() => {
     if (window && !window.Kakao.isInitialized()) {
       const Kakao = window.Kakao;
-      window.Kakao.init('abd52d4f71bf72ffebcf85c674281bb4')
       setKakaoLogin(() => Kakao);
-      console.log(Kakao.isInitialized())
+      window.Kakao.init("abd52d4f71bf72ffebcf85c674281bb4");
     }
-  }, [])
+  }, []);
 
   const onKakaoLogin = () => {
     kakaoLogin?.Auth.authorize({
-      redirectUri: 'http://localhost:3000/kakao-login',
-      state: 'culetter'
-    })
-  }
+      redirectUri: "http://localhost:3000/kakao-login",
+      state: "culetter",
+    });
+  };
 
   return (
     <>
@@ -88,7 +91,7 @@ const IndexPage = () => {
       <div>{JSON.stringify(userInfo)}</div>
       <div>{JSON.stringify(accessToken)}</div>
       <button onClick={onLogout}>로그아웃</button>
-      
+
       {/* eslint-disable-next-line */}
       <button id="custom-login-btn" onClick={onKakaoLogin}>
         <img
@@ -98,7 +101,7 @@ const IndexPage = () => {
         />
       </button>
     </>
-  )
-}
+  );
+};
 
-export default IndexPage
+export default IndexPage;

--- a/client/src/pages/IndexPage.tsx
+++ b/client/src/pages/IndexPage.tsx
@@ -1,5 +1,6 @@
 import axios from "axios";
 import React, { useContext, useEffect, useState } from "react";
+import kakaoUserLogout from "../api/auth/kakao/kakaoUserLogout";
 import { UserContext } from "../contexts/UserContext";
 
 declare global {
@@ -86,6 +87,16 @@ const IndexPage = () => {
     });
   };
 
+  const onKakaoLogout = async () => {
+    const res = await kakaoUserLogout();
+
+    if (res.status === 200) {
+      window.localStorage.removeItem("access_token");
+      setUserInfo(() => ({}));
+      setAccessToken(() => "");
+    }
+  };
+
   return (
     <>
       <div id="naverIdLogin"></div>
@@ -102,6 +113,9 @@ const IndexPage = () => {
             alt="카카오 로그인 버튼"
           />
         </button>
+      )}
+      {accessToken && (
+        <button onClick={onKakaoLogout}>카카오 계정 로그아웃</button>
       )}
     </>
   );

--- a/client/src/pages/IndexPage.tsx
+++ b/client/src/pages/IndexPage.tsx
@@ -1,6 +1,6 @@
 
 import axios from 'axios';
-import React, { useContext, useEffect } from 'react'
+import React, { useContext, useEffect, useState } from 'react'
 import { UserContext } from '../contexts/UserContext';
 
 declare global {
@@ -62,14 +62,26 @@ const IndexPage = () => {
     getFn()
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [])
+
+
+  const [kakaoLogin, setKakaoLogin] = useState<any>(null);
   
   useEffect(() => {
     if (window && !window.Kakao.isInitialized()) {
       const Kakao = window.Kakao;
       window.Kakao.init('abd52d4f71bf72ffebcf85c674281bb4')
+      setKakaoLogin(() => Kakao);
       console.log(Kakao.isInitialized())
     }
   }, [])
+
+  const onKakaoLogin = () => {
+    kakaoLogin?.Auth.authorize({
+      redirectUri: 'http://localhost:3000/kakao-login',
+      state: 'culetter'
+    })
+  }
+
   return (
     <>
       <div id="naverIdLogin"></div>
@@ -78,13 +90,13 @@ const IndexPage = () => {
       <button onClick={onLogout}>로그아웃</button>
       
       {/* eslint-disable-next-line */}
-      <a id="custom-login-btn">
+      <button id="custom-login-btn" onClick={onKakaoLogin}>
         <img
           src="//k.kakaocdn.net/14/dn/btroDszwNrM/I6efHub1SN5KCJqLm1Ovx1/o.jpg"
           width="222"
           alt="카카오 로그인 버튼"
         />
-      </a>
+      </button>
     </>
   )
 }

--- a/client/src/pages/IndexPage.tsx
+++ b/client/src/pages/IndexPage.tsx
@@ -62,13 +62,29 @@ const IndexPage = () => {
     getFn()
     /* eslint-disable-next-line react-hooks/exhaustive-deps */
   }, [])
-
+  
+  useEffect(() => {
+    if (window && !window.Kakao.isInitialized()) {
+      const Kakao = window.Kakao;
+      window.Kakao.init('abd52d4f71bf72ffebcf85c674281bb4')
+      console.log(Kakao.isInitialized())
+    }
+  }, [])
   return (
     <>
       <div id="naverIdLogin"></div>
       <div>{JSON.stringify(userInfo)}</div>
       <div>{JSON.stringify(accessToken)}</div>
       <button onClick={onLogout}>로그아웃</button>
+      
+      {/* eslint-disable-next-line */}
+      <a id="custom-login-btn">
+        <img
+          src="//k.kakaocdn.net/14/dn/btroDszwNrM/I6efHub1SN5KCJqLm1Ovx1/o.jpg"
+          width="222"
+          alt="카카오 로그인 버튼"
+        />
+      </a>
     </>
   )
 }

--- a/client/src/pages/IndexPage.tsx
+++ b/client/src/pages/IndexPage.tsx
@@ -28,7 +28,8 @@ const IndexPage = () => {
         },
       }
     );
-    console.log(res);
+
+    console.log("Logout: ", res);
   };
 
   // const url = window.opener.document.location.href;
@@ -89,17 +90,19 @@ const IndexPage = () => {
     <>
       <div id="naverIdLogin"></div>
       <div>{JSON.stringify(userInfo)}</div>
-      <div>{JSON.stringify(accessToken)}</div>
+      <div>{accessToken}</div>
       <button onClick={onLogout}>로그아웃</button>
 
       {/* eslint-disable-next-line */}
-      <button id="custom-login-btn" onClick={onKakaoLogin}>
-        <img
-          src="//k.kakaocdn.net/14/dn/btroDszwNrM/I6efHub1SN5KCJqLm1Ovx1/o.jpg"
-          width="222"
-          alt="카카오 로그인 버튼"
-        />
-      </button>
+      {!accessToken && (
+        <button id="custom-login-btn" onClick={onKakaoLogin}>
+          <img
+            src="//k.kakaocdn.net/14/dn/btroDszwNrM/I6efHub1SN5KCJqLm1Ovx1/o.jpg"
+            width="222"
+            alt="카카오 로그인 버튼"
+          />
+        </button>
+      )}
     </>
   );
 };

--- a/client/src/pages/KakaoLoginPage.tsx
+++ b/client/src/pages/KakaoLoginPage.tsx
@@ -1,12 +1,6 @@
-import React, { useEffect } from "react";
+import React, { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import getAuthToken from "../api/auth/kakao/getAuthToken";
-
-declare global {
-  interface Window {
-    naver: any;
-  }
-}
 
 const KakaoLoginPage = () => {
   const [params] = useSearchParams();
@@ -14,13 +8,13 @@ const KakaoLoginPage = () => {
   useEffect(() => {
     async function getToken() {
       const code = params.get("code");
-      const token = await getAuthToken(code);
+      const res = await getAuthToken(code);
+      console.log(res);
 
-      window.localStorage.setItem("ACCESS_TOKEN", JSON.stringify(token));
+      // window.localStorage.setItem("ACCESS_TOKEN", JSON.stringify(token));
     }
-
     getToken();
-  });
+  }, []);
 
   return <div id="kakaoIdLogin">KakaoLoginPage</div>;
 };

--- a/client/src/pages/KakaoLoginPage.tsx
+++ b/client/src/pages/KakaoLoginPage.tsx
@@ -1,20 +1,27 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import getAuthToken from "../api/auth/kakao/getAuthToken";
 
 const KakaoLoginPage = () => {
   const [params] = useSearchParams();
+  const isRequested = useRef(false);
 
   useEffect(() => {
+    if (isRequested.current) return;
     async function getToken() {
       const code = params.get("code");
       const res = await getAuthToken(code);
       console.log(res);
 
       // window.localStorage.setItem("ACCESS_TOKEN", JSON.stringify(token));
+      isRequested.current = true;
     }
     getToken();
-  }, []);
+
+    return () => {
+      isRequested.current = true;
+    };
+  }, [isRequested, params]);
 
   return <div id="kakaoIdLogin">KakaoLoginPage</div>;
 };

--- a/client/src/pages/KakaoLoginPage.tsx
+++ b/client/src/pages/KakaoLoginPage.tsx
@@ -1,5 +1,6 @@
-
-import React from 'react'
+import React, { useEffect } from "react";
+import { useSearchParams } from "react-router-dom";
+import getAuthToken from "../api/auth/kakao/getAuthToken";
 
 declare global {
   interface Window {
@@ -8,12 +9,20 @@ declare global {
 }
 
 const KakaoLoginPage = () => {
+  const [params] = useSearchParams();
 
-  return (
-    <div id="kakaoIdLogin">
-        KakaoLoginPage
-    </div>
-  )
-}
+  useEffect(() => {
+    async function getToken() {
+      const code = params.get("code");
+      const token = await getAuthToken(code);
 
-export default KakaoLoginPage
+      window.localStorage.setItem("ACCESS_TOKEN", JSON.stringify(token));
+    }
+
+    getToken();
+  });
+
+  return <div id="kakaoIdLogin">KakaoLoginPage</div>;
+};
+
+export default KakaoLoginPage;

--- a/client/src/pages/KakaoLoginPage.tsx
+++ b/client/src/pages/KakaoLoginPage.tsx
@@ -1,0 +1,19 @@
+
+import React from 'react'
+
+declare global {
+  interface Window {
+    naver: any;
+  }
+}
+
+const KakaoLoginPage = () => {
+
+  return (
+    <div id="kakaoIdLogin">
+        KakaoLoginPage
+    </div>
+  )
+}
+
+export default KakaoLoginPage

--- a/client/src/pages/KakaoLoginPage.tsx
+++ b/client/src/pages/KakaoLoginPage.tsx
@@ -1,24 +1,53 @@
-import React, { useEffect, useRef } from "react";
-import { useSearchParams } from "react-router-dom";
+import React, { useContext, useEffect, useRef } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import getAuthToken from "../api/auth/kakao/getAuthToken";
 import getKakaoUserInfo from "../api/auth/kakao/getKakaoUserInfo";
+import { UserContext } from "../contexts/UserContext";
 
 const KakaoLoginPage = () => {
+  const navigate = useNavigate();
   const [params] = useSearchParams();
   const isRequested = useRef(false);
+
+  const { userInfo, setUserInfo, setAccessToken } = useContext(UserContext);
 
   useEffect(() => {
     if (isRequested.current) return;
     async function getToken() {
       const code = params.get("code");
       const res = await getAuthToken(code);
-      console.log(res);
 
-      // window.localStorage.setItem("ACCESS_TOKEN", JSON.stringify(token));
+      if (res.access_token) {
+        window.localStorage.setItem(
+          "access_token",
+          JSON.stringify(res.access_token)
+        );
+
+        setAccessToken(() => res.access_token);
+      }
+
       isRequested.current = true;
 
-      const userInfo = await getKakaoUserInfo(res.access_token);
-      console.log(userInfo);
+      const user = await getKakaoUserInfo(res.access_token);
+
+      const requiredInfo = user.properties;
+      const optionalInfo = user.kakao_account;
+
+      setUserInfo(() => ({
+        ...userInfo,
+        nickname: requiredInfo.nickname,
+        profile_image: requiredInfo.profile_image,
+        thumbnail_image: requiredInfo.thumbnail_image,
+        email:
+          optionalInfo.is_email_valid && optionalInfo.is_email_verified
+            ? optionalInfo.email
+            : null,
+        birthday: optionalInfo.has_birthday ? optionalInfo.birthday : null,
+        gender: optionalInfo.has_gender ? optionalInfo.gender : null,
+        ageRange: optionalInfo.has_age_range ? optionalInfo.age_range : null,
+      }));
+
+      navigate("/", { replace: true });
     }
 
     getToken();
@@ -26,7 +55,9 @@ const KakaoLoginPage = () => {
     return () => {
       isRequested.current = true;
     };
-  }, [isRequested, params]);
+
+    /* eslint-disable react-hooks/exhaustive-deps */
+  }, [isRequested, params, setUserInfo, navigate]);
 
   return <div id="kakaoIdLogin">KakaoLoginPage</div>;
 };

--- a/client/src/pages/KakaoLoginPage.tsx
+++ b/client/src/pages/KakaoLoginPage.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef } from "react";
 import { useSearchParams } from "react-router-dom";
 import getAuthToken from "../api/auth/kakao/getAuthToken";
+import getKakaoUserInfo from "../api/auth/kakao/getKakaoUserInfo";
 
 const KakaoLoginPage = () => {
   const [params] = useSearchParams();
@@ -15,7 +16,11 @@ const KakaoLoginPage = () => {
 
       // window.localStorage.setItem("ACCESS_TOKEN", JSON.stringify(token));
       isRequested.current = true;
+
+      const userInfo = await getKakaoUserInfo(res.access_token);
+      console.log(userInfo);
     }
+
     getToken();
 
     return () => {

--- a/client/src/react-app-env.d.ts
+++ b/client/src/react-app-env.d.ts
@@ -1,1 +1,6 @@
 /// <reference types="react-scripts" />
+
+interface Window {
+    naver: any;
+    Kakao: any;
+}

--- a/client/src/setupProxy.js
+++ b/client/src/setupProxy.js
@@ -1,13 +1,10 @@
-const { createProxyMiddleware } = require('http-proxy-middleware')
+const { createProxyMiddleware } = require("http-proxy-middleware");
 
 module.exports = (app) => {
-    app.use(
-      createProxyMiddleware(
-        ['/auth/naver'],
-        {
-          target: process.env.REACT_APP_SERVER_API_END_POINT,
-          changeOrigin: true
-        }
-      )
-    );
-}
+  app.use(
+    createProxyMiddleware(["/auth/naver", "/auth/kakao"], {
+      target: process.env.REACT_APP_SERVER_API_END_POINT,
+      changeOrigin: true,
+    })
+  );
+};

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -22,7 +22,6 @@
     "noImplicitAny": false
   },
   "include": [
-    "src",
-    "./window.d.ts"
+    "src"
   ]
 }

--- a/client/window.d.ts
+++ b/client/window.d.ts
@@ -1,5 +1,0 @@
-declare global {
-  interface Window {
-    naver: any;
-  }
-}


### PR DESCRIPTION
# 🌈 설명

기나긴 잠수(?)와 인내의 시간 끝에, 카카오 로그인에 관한 클라이언트/백엔드 통신을 모두 구현했습니다 🥰

# 🙇🏻‍♂️ 구현 방법

저는 다음과 같은 방식으로 구현했어요.
다음 공식문서에 담긴 이미지를 참고하며 개발했습니다!

![카카오로그인](https://developers.kakao.com/docs/latest/ko/assets/style/images/kakaologin/kakaologin_sequence.png)

1. SDK를 통해 로그인을 시도합니다. SDK는 서버측에서 받거나 `iframe`을 끼우기보다는, 순수 코드를 받아오기 위함으로 사용했습니다.
2. code를 기반으로 백엔드 측에서 카카오 로그인 REST API 통신을 시도합니다.
3. 이를 통해 토큰을 받아오면, 스토리지에 저장하고 사용자 정보를 조회합니다.
4. 이후 로그아웃을 시도하면 스토리지에 저장된 토큰 값을 없애고, 유저 정보 및 토큰 상태를 비웁니다.

# 🔥 어려웠던 점

## `authorization code` 방식에 대해 배우다.

처음부터 네이버 로그인 API를 적용하지 말고, 카카오로 시작할 걸 그랬습니다. 😥
좀 더 정석적인 방법으로 배웠으면 이렇게 헤매지도 않았을 것 같았거든요. 
한편으로는 더 어려운 난이도(?)로 개발하니, 이제 `oauth`의 모든 로직을 통달해버린(?) 느낌도 들어서, 나쁘지 않아요. 굿! 🙆🏻

## `axios`도 꽤나 난해하다.

생각보다 `axios` 사용이 미숙하다는 것을 여실히 깨달았습니다.
어떤 때에는 `data`를 `headers`를 설정하는 `config` parameter와 분리해줘야만 동작하고, 어떤 때에는 함께 넣어야 동작하는 케이스들이 존재했습니다. (이때문에 거의 하루를 버렸다고...)

`axios` 공식 문서를 좀 더 톺아봐서, 더 정확한 API 통신 방법을 익혀야함을 배웠어요! 🥰

